### PR TITLE
Using Extra Repositories in Regression Testing

### DIFF
--- a/Tools/RegressionTesting/regtest.py
+++ b/Tools/RegressionTesting/regtest.py
@@ -243,12 +243,12 @@ def test_suite(argv):
 
         if "boxlib" in nouplist: suite.repos["BoxLib"].update = False
         if suite.srcName.lower() in nouplist: suite.repos["source"].update = False
-        if suite.extSrcName.lower() in nouplist: suite.repos["extra_source"].update = False
+        if suite.extSrcName.lower() in nouplist: suite.repos["extra-source"].update = False
 
         # each extra build directory has its own update flag
         for n, e in enumerate(suite.extra_build_names):
             if e.lower() in nouplist:
-                suite.repos["extra_build-{}".format(n)].update = False
+                suite.repos["extra-build-{}".format(n)].update = False
 
     os.chdir(suite.testTopDir)
 

--- a/Tools/RegressionTesting/regtest.py
+++ b/Tools/RegressionTesting/regtest.py
@@ -853,7 +853,9 @@ def test_suite(argv):
                         suite.log.warn("unable to tar output file {}".format(pfile))
 
                     else:
-                        shutil.rmtree(pfile)
+                        try: shutil.rmtree(pfile)
+                        except:
+                            suite.log.warn("unable to remove {}".format(pfile))
 
 
         #----------------------------------------------------------------------


### PR DESCRIPTION
Fixing bug where extra repositories in regression testing would not build. This was done by changing references of extra_* to extra-* to be consistent with other sections of the code.