### PR TITLE
Adding exception handling to a particular shutil.rmtree().

### DIFF
--- a/Tools/RegressionTesting/regtest.py
+++ b/Tools/RegressionTesting/regtest.py
@@ -853,7 +853,9 @@ def test_suite(argv):
                         suite.log.warn("unable to tar output file {}".format(pfile))
 
                     else:
-                        shutil.rmtree(pfile)
+                        try: shutil.rmtree(pfile)
+                        except:
+                            suite.log.warn("unable to remove {}".format(pfile))
 
 
         #----------------------------------------------------------------------

--- a/Tools/RegressionTesting/regtest.py
+++ b/Tools/RegressionTesting/regtest.py
@@ -854,7 +854,7 @@ def test_suite(argv):
 
                     else:
                         try: shutil.rmtree(pfile)
-                        except:
+                        except OSError:
                             suite.log.warn("unable to remove {}".format(pfile))
 
 


### PR DESCRIPTION
This command can cause errors on certain filesystems and the test suite can completely fail before finishing. This is particularly evident on Peregrine, errno 17 'file exists' occurs when attempting to delete the final top level *_pltXXXX directory in each test even though all the files in the directory are successfully deleted.