### PR TITLE
add USE_GPROF to enable profiling with gprof

### DIFF
--- a/Tools/C_mk/comps/gnu.mak
+++ b/Tools/C_mk/comps/gnu.mak
@@ -40,6 +40,16 @@ else
 
 endif
 
+
+ifeq ($(USE_GPROF),TRUE)
+
+  CXXFLAGS += -pg
+  CFLAGS += -pg
+  FFLAGS += -pg
+  F90FLAGS += -pg
+
+endif
+
 ########################################################################
 
 ifeq ($(gcc_major_version),4)


### PR DESCRIPTION
@WeiqunZhang trying this via a PR.  This allows us to use `gprof` to profile Castro with the GNU compilers by building with:

```
make USE_GPROF=TRUE
```
