### PR TITLE
continue if we encounter a module that is not provided

### DIFF
--- a/Tools/F_scripts/dep.py
+++ b/Tools/F_scripts/dep.py
@@ -270,6 +270,7 @@ def doit(prefix, search_path, files, cpp, debug=False):
             except KeyError:
                 print("warning: module {} required by {} not found".format(d, sf.name), 
                       file=sys.stderr)
+                print("$(warning module {} required by {} not found)".format(d, sf.name))
                 continue
 
             # skip the case where a file provides the module it needs

--- a/Tools/F_scripts/dep.py
+++ b/Tools/F_scripts/dep.py
@@ -270,6 +270,7 @@ def doit(prefix, search_path, files, cpp, debug=False):
             except KeyError:
                 print("warning: module {} required by {} not found".format(d, sf.name), 
                       file=sys.stderr)
+                continue
 
             # skip the case where a file provides the module it needs
             # on its own; otherwise output the dependency line


### PR DESCRIPTION
if we file requests a module that nothing provides then continue on to the next.  This was the intended behavior originally, but we missed a `continue` statement.  This allows for system-provided
modules to work without them in the `IGNORES` list.  

This fixes a bug that @bcfriesen  ran into.