### PR TITLE
fix case where no files are found for copying

### DIFF
--- a/Tools/RegressionTesting/regtest.py
+++ b/Tools/RegressionTesting/regtest.py
@@ -81,7 +81,7 @@ def copy_benchmarks(old_full_test_dir, full_web_dir, test_list, bench_dir, log):
             else:
                 p = t.compareFile
 
-        if not p == "":
+        if p != "" and p is not None:
             if p.endswith(".tgz"):
                 try:
                     tg = tarfile.open(name=p, mode="r:gz")


### PR DESCRIPTION
this fixes an issue when using `--copy_benchmarks` on tests that crashed and did not output.