### PR TITLE
cmake: add an option for compiling with -fPIC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ OPTION (ENABLE_FORTRAN_MPI "Enable Fortran MPI Communicator" ON)
 OPTION (ENABLE_MG_FBOXLIB "Enable Fortran for MultiGrid Solver" OFF)
 OPTION (ENABLE_FBASELIB "Enable Fortran BaseLib" OFF)
 OPTION (ENABLE_CXX11 "Enable C++11" ON)
+OPTION (ENABLE_POSITION_INDEPENDENT_CODE "Compile with position-independent code enabled" OFF)
 
 
 # Below, we have set some of the switches for reasonable default behavior, these can be 

--- a/Tools/CMake/CCSEOptions.cmake
+++ b/Tools/CMake/CCSEOptions.cmake
@@ -11,6 +11,10 @@ enable_language(C)
 enable_language(CXX)
 enable_language(Fortran)
 
+if (ENABLE_POSITION_INDEPENDENT_CODE)
+  set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+endif ()
+
 # No idea why we need this.
 # I think it was required for Franklin build. -- lpritch
 if(PREFER_STATIC_LIBRARIES)


### PR DESCRIPTION
This is required to support linking the library from an executable which
uses other shared libraries.