### PR TITLE
Changes needed to use the regression test suite with WarpX's python mode

### DIFF
--- a/Tools/RegressionTesting/regtest.py
+++ b/Tools/RegressionTesting/regtest.py
@@ -377,7 +377,8 @@ def test_suite(argv):
         suite.log.log("copying files to run directory...")
 
         needed_files = []
-        needed_files.append((executable, "move"))
+        if executable is not None:
+            needed_files.append((executable, "move"))
 
         needed_files.append((test.inputFile, "copy"))
         # strip out any sub-directory from the build dir
@@ -466,6 +467,9 @@ def test_suite(argv):
 
         if args.with_valgrind:
             base_cmd = "valgrind " + args.valgrind_options + " " + base_cmd
+
+        if test.customRunCmd is not None:
+            base_cmd = test.customRunCmd
 
         suite.run_test(test, base_cmd)
 

--- a/Tools/RegressionTesting/suite.py
+++ b/Tools/RegressionTesting/suite.py
@@ -104,6 +104,8 @@ class Test(object):
         self.compile_successful = False  # filled automatically
         self.compare_successful = False  # filled automatically
 
+        self.customRunCmd = None
+
     def __lt__(self, other):
         return self.value() < other.value()
 


### PR DESCRIPTION
This allows users to override the default execution command from their test .ini files. This is needed to get the regressions to work with WarpX problem setups that are run through a python script instead of a C++ executable. 

If this is accepted, I'll make the same changes in AMReX.