### PR TITLE
Capture the return code of analysis scripts in the test suite

### DIFF
--- a/Tools/C_mk/Make.machines
+++ b/Tools/C_mk/Make.machines
@@ -16,7 +16,7 @@ endif
 
 CCSE_MACHINES := angilas atragon baragon battra ebirah gamera gigan
 CCSE_MACHINES += gimantis godzilla gojira hedorah kumonga manda
-CCSE_MACHINES += megalon mothra rodan varan naphta orga
+CCSE_MACHINES += megalon mothra rodan varan naphta orga ghidorah
 ifeq ($(host_name), $(findstring $(host_name), $(CCSE_MACHINES)))
   which_site := ccse
   which_computer := $(host_name)

--- a/Tools/RegressionTesting/regtest.py
+++ b/Tools/RegressionTesting/regtest.py
@@ -768,9 +768,21 @@ def test_suite(argv):
 
                         shutil.copy(tool, os.getcwd())
 
-                        option = eval("suite.{}".format(test.analysisMainArgs))
-                        test_util.run("{} {} {}".format(os.path.basename(test.analysisRoutine),
-                                                        option, output_file))
+                        if test.analysisMainArgs == "":
+                            option = ""
+                        else:
+                            option = eval("suite.{}".format(test.analysisMainArgs))
+
+                        cmd_name = os.path.basename(test.analysisRoutine)
+                        cmd_string = "./{} {} {}".format(cmd_name, option, output_file)
+                        _, _, rc = test_util.run(cmd_string)
+
+                        if rc == 0:
+                            analysis_successful = True
+                        else:
+                            analysis_successful = False
+
+                        test.compare_successful = test.compare_successful and analysis_successful
 
             else:
                 if test.doVis or test.analysisRoutine != "":


### PR DESCRIPTION
This will let us perform additional regression checks inside analysis scripts and have their return codes contribute to the test's success or failure. Since the scripts return 0 by default*, this shouldn't affect existing tests. 

I also added my machine name to Make.machines, which was needed to build Amrvis. 

*This always seems to be true, but it doesn't *have* to be true, at least as far as I've been able to find online. We could always require the scripts to explicitly return exit codes, if needed.

 