### PR TITLE
Add an explicit dependency for box_f on box_c

### DIFF
--- a/Src/F_BaseLib/CMakeLists.txt
+++ b/Src/F_BaseLib/CMakeLists.txt
@@ -47,6 +47,7 @@ preprocess_boxlib_fortran(FPP_out_files ${FPP_source_files})
 set(local_source_files ${C_source_files} ${CXX_source_files} ${F77_source_files} ${FPP_out_files} ${F90_source_files})
 set(local_header_files ${CXX_header_files} ${F77_header_files} ${FPP_header_files} ${F90_header_files})
 add_library(box_f OBJECT ${local_source_files})
+add_dependencies(box_f box_c)
 
 add_install_include_file(${local_header_files})
 


### PR DESCRIPTION
In a large parallel build, the file vector_i.f90 could end up being
compiled before mempool_module.mod was generated. Since vector_i.f90
requires mempool_module.mod, the build would fail. Adding a dependency
ensures mempool_module.mod exists before being referred to.